### PR TITLE
use `callsites` to get the caller's filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that has 2 lines of code:
 
 ```js
 import blog from "https://deno.land/x/blog/blog.tsx";
-blog(import.meta.url);
+blog();
 ```
 
 ## Getting started
@@ -35,7 +35,7 @@ You can customize your blog as follows:
 
 ```js
 import blog from "https://deno.land/x/blog/blog.tsx";
-blog(import.meta.url, {
+blog({
   author: "Denobot",
   title: "My blog title",
   subtitle: "Subtitle",

--- a/blog.tsx
+++ b/blog.tsx
@@ -23,6 +23,7 @@ import type { Reporter as GaReporter } from "https://deno.land/x/g_a@0.1.2/mod.t
 import { Feed } from "https://esm.sh/feed@4.2.2?pin=v57";
 import type { Item as FeedItem } from "https://esm.sh/feed@4.2.2?pin=v57";
 import removeMarkdown from "https://esm.sh/remove-markdown?pin=v57";
+import callsites from "https://raw.githubusercontent.com/kt3k/callsites/v1.0.0/mod.ts";
 export interface BlogSettings {
   title?: string;
   author?: string;
@@ -56,14 +57,14 @@ const POSTS = new Map<string, Post>();
  *
  * ```js
  * import blog from "https://deno.land/x/blog/blog.tsx";
- * blog(import.meta.url);
+ * blog();
  * ```
  *
  * Configure it:
  *
  * ```js
  * import blog from "https://deno.land/x/blog/blog.tsx";
- * blog(import.meta.url, {
+ * blog({
  *   title: "My blog title",
  *   subtitle: "Subtitle",
  *   header:
@@ -72,7 +73,8 @@ const POSTS = new Map<string, Post>();
  * });
  * ```
  */
-export default async function blog(url: string, settings?: BlogSettings) {
+export default async function blog(settings?: BlogSettings) {
+  const url = callsites()[1].getFileName()!;
   const blogSettings = await configureBlog(IS_DEV, url, settings);
 
   let gaReporter: undefined | GaReporter;

--- a/init.ts
+++ b/init.ts
@@ -32,7 +32,7 @@ This is my first blog post!
 
 const MAIN_CONTENTS = `import blog from "${MAIN_FILE_URL}";
 
-blog(import.meta.url, {
+blog({
   title: "My blog",
   author: "An author",
   header: "This is my new blog",


### PR DESCRIPTION
Uses [callsites](https://github.com/kt3k/callsites) utility to get the caller's filename. This reduces the boilerplate first argument of `blog` function