### PR TITLE
feat: add lang & timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ blog({
     { title: "GitHub", url: "https://github.com/denobot" },
     { title: "Twitter", url: "https://twitter.com/denobot" },
   ],
+  lang: "en",
+  timezone: "en-US",
   middlewares: [
     ga("UA-XXXXXXXX-X"),
     redirects({

--- a/blog.tsx
+++ b/blog.tsx
@@ -279,6 +279,7 @@ export async function handler(
 
   if (pathname === "/") {
     return html({
+      lang:blogState.lang,
       title: blogState.title ?? "My Blog",
       meta: {
         "description": blogState.description,
@@ -309,6 +310,7 @@ export async function handler(
   const post = POSTS.get(pathname);
   if (post) {
     return html({
+      lang:blogState.lang,
       title: post.title,
       meta: {
         "description": post.snippet,
@@ -363,7 +365,7 @@ function serveRSS(
     description: state.description,
     id: `${origin}/blog`,
     link: `${origin}/blog`,
-    language: "en",
+    language: state.lang,
     favicon: `${origin}/favicon.ico`,
     copyright: copyright,
     generator: "Feed (https://github.com/jpmonette/feed) for Deno",

--- a/blog.tsx
+++ b/blog.tsx
@@ -279,7 +279,7 @@ export async function handler(
 
   if (pathname === "/") {
     return html({
-      lang:blogState.lang,
+      lang: blogState.lang,
       title: blogState.title ?? "My Blog",
       meta: {
         "description": blogState.description,
@@ -310,7 +310,7 @@ export async function handler(
   const post = POSTS.get(pathname);
   if (post) {
     return html({
-      lang:blogState.lang,
+      lang: blogState.lang,
       title: post.title,
       meta: {
         "description": post.snippet,

--- a/components.tsx
+++ b/components.tsx
@@ -102,6 +102,7 @@ export function Index({ state, posts }: IndexProps) {
             <PostCard
               post={post}
               key={post.pathname}
+              timezone={state.timezone ?? 'en-US'}
             />
           ))}
         </div>
@@ -112,7 +113,7 @@ export function Index({ state, posts }: IndexProps) {
   );
 }
 
-function PostCard({ post }: { post: Post }) {
+function PostCard({ post, timezone }: { post: Post, timezone: string }) {
   return (
     <div class="pt-12 first:pt-0">
       <h3 class="text-2xl font-bold">
@@ -121,7 +122,7 @@ function PostCard({ post }: { post: Post }) {
         </a>
       </h3>
       <p class="text-gray-500/80">
-        <PrettyDate date={post.publishDate} />
+        <PrettyDate date={post.publishDate} timezone={timezone} />
       </p>
       <p class="mt-3 text-gray-600">
         {post.snippet}
@@ -146,7 +147,7 @@ interface PostPageProps {
 
 export function PostPage({ post, state }: PostPageProps) {
   const html = gfm.render(post.markdown);
-
+  
   return (
     <div class="max-w-screen-sm px-6 pt-8 mx-auto">
       <div class="pb-16">
@@ -184,7 +185,7 @@ export function PostPage({ post, state }: PostPageProps) {
               By {state.author || post.author} at {" "}
             </span>
           )}
-          <PrettyDate date={post.publishDate} />
+          <PrettyDate date={post.publishDate} timezone={state.timezone}/>
         </p>
         <div
           class="mt-8 markdown-body"
@@ -252,8 +253,8 @@ function Tooltip(
   );
 }
 
-function PrettyDate({ date }: { date: Date }) {
-  const formatted = date.toISOString().split("T")[0].replaceAll("-", "/");
+function PrettyDate({ date, timezone }: { date: Date, timezone?: string }) {
+  const formatted = date.toLocaleDateString(timezone ?? 'en-US');
   return <time dateTime={date.toISOString()}>{formatted}</time>;
 }
 

--- a/components.tsx
+++ b/components.tsx
@@ -102,7 +102,7 @@ export function Index({ state, posts }: IndexProps) {
             <PostCard
               post={post}
               key={post.pathname}
-              timezone={state.timezone ?? 'en-US'}
+              timezone={state.timezone ?? "en-US"}
             />
           ))}
         </div>
@@ -113,7 +113,7 @@ export function Index({ state, posts }: IndexProps) {
   );
 }
 
-function PostCard({ post, timezone }: { post: Post, timezone: string }) {
+function PostCard({ post, timezone }: { post: Post; timezone: string }) {
   return (
     <div class="pt-12 first:pt-0">
       <h3 class="text-2xl font-bold">
@@ -147,7 +147,6 @@ interface PostPageProps {
 
 export function PostPage({ post, state }: PostPageProps) {
   const html = gfm.render(post.markdown);
-  
   return (
     <div class="max-w-screen-sm px-6 pt-8 mx-auto">
       <div class="pb-16">
@@ -185,7 +184,7 @@ export function PostPage({ post, state }: PostPageProps) {
               By {state.author || post.author} at {" "}
             </span>
           )}
-          <PrettyDate date={post.publishDate} timezone={state.timezone}/>
+          <PrettyDate date={post.publishDate} timezone={state.timezone} />
         </p>
         <div
           class="mt-8 markdown-body"
@@ -253,8 +252,8 @@ function Tooltip(
   );
 }
 
-function PrettyDate({ date, timezone }: { date: Date, timezone?: string }) {
-  const formatted = date.toLocaleDateString(timezone ?? 'en-US');
+function PrettyDate({ date, timezone }: { date: Date; timezone?: string }) {
+  const formatted = date.toLocaleDateString(timezone ?? "en-US");
   return <time dateTime={date.toISOString()}>{formatted}</time>;
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -27,6 +27,8 @@ export interface BlogSettings {
   background?: string;
   ogImage?: string;
   middlewares?: BlogMiddleware[];
+  lang?: string;
+  timezone?: string;
 }
 
 export interface BlogState extends BlogSettings {


### PR DESCRIPTION
This commit adds language support by adding lang & timezone to the blog() function. 

The default option is English and en-US.