### PR TITLE
feat: add canonicalUrl fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": true
+}

--- a/blog.tsx
+++ b/blog.tsx
@@ -291,6 +291,12 @@ export async function handler(
         "twitter:image": blogState.ogImage ?? blogState.cover,
         "twitter:card": blogState.ogImage ? "summary_large_image" : undefined,
       },
+      links: blogState.canonicalUrl ? [
+        {
+          rel: "canonical",
+          href: blogState.canonicalUrl,
+        }
+      ] : undefined,
       styles: [
         ...(blogState.style ? [blogState.style] : []),
         ...(blogState.background
@@ -322,6 +328,12 @@ export async function handler(
         "twitter:image": post.ogImage,
         "twitter:card": post.ogImage ? "summary_large_image" : undefined,
       },
+      links: blogState.canonicalUrl ? [
+        {
+          rel: "canonical",
+          href: new URL(post.pathname, blogState.canonicalUrl).href,
+        }
+      ] : undefined,
       styles: [
         gfm.CSS,
         `.markdown-body { --color-canvas-default: transparent; --color-canvas-subtle: #edf0f2; --color-border-muted: rgba(128,128,128,0.2); } .markdown-body img + p { margin-top: 16px; }`,
@@ -357,7 +369,7 @@ function serveRSS(
   state: BlogState,
   posts: Map<string, Post>,
 ): Response {
-  const url = state.rssDomain ? new URL(state.rssDomain) : new URL(req.url);
+  const url = state.canonicalUrl ? new URL(state.canonicalUrl) : new URL(req.url);
   const origin = url.origin;
   const copyright = `Copyright ${new Date().getFullYear()} ${origin}`;
   const feed = new Feed({

--- a/blog.tsx
+++ b/blog.tsx
@@ -294,7 +294,7 @@ export async function handler(
       links: blogState.canonicalUrl ? [
         {
           rel: "canonical",
-          href: blogState.canonicalUrl,
+          href: new URL(blogState.canonicalUrl).href,
         }
       ] : undefined,
       styles: [

--- a/deps.ts
+++ b/deps.ts
@@ -19,7 +19,7 @@ export {
   h,
   html,
   type VNode,
-} from "https://deno.land/x/htm@0.0.7/mod.tsx";
+} from "../html/mod.tsx";
 export { parse as frontMatter } from "https://deno.land/x/frontmatter@v0.1.4/mod.ts";
 export {
   createReporter,

--- a/deps.ts
+++ b/deps.ts
@@ -19,7 +19,7 @@ export {
   h,
   html,
   type VNode,
-} from "https://deno.land/x/htm@0.0.6/mod.tsx";
+} from "https://deno.land/x/htm@0.0.7/mod.tsx";
 export { parse as frontMatter } from "https://deno.land/x/frontmatter@v0.1.4/mod.ts";
 export {
   createReporter,

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,7 +30,7 @@ export interface BlogSettings {
   middlewares?: BlogMiddleware[];
   lang?: string;
   timezone?: string;
-  rssDomain?: string;
+  canonicalUrl?: string;
 }
 
 export interface BlogState extends BlogSettings {


### PR DESCRIPTION
changes `rssDomain` to `canonicalUrl` as per denoland#20 and uses that both in the RSS as well as generating the post data