### PR TITLE
add unocss customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can customize your blog as follows:
 
 ```js
 import blog, { ga, redirects } from "https://deno.land/x/blog/blog.tsx";
-import { unocss_opts } from './unocss.ts'
+import { unocss_opts } from "./unocss.ts";
 
 blog({
   author: "Dino",
@@ -59,7 +59,7 @@ blog({
       "bar": "my_post2",
     }),
   ],
-  unocss: unocss_opts // check https://github.com/unocss/unocss
+  unocss: unocss_opts, // check https://github.com/unocss/unocss
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can customize your blog as follows:
 
 ```js
 import blog, { ga, redirects } from "https://deno.land/x/blog/blog.tsx";
+import { unocss_opts } from './unocss.ts'
 
 blog({
   author: "Dino",
@@ -58,6 +59,7 @@ blog({
       "bar": "my_post2",
     }),
   ],
+  unocss: unocss_opts // check https://github.com/unocss/unocss
 });
 ```
 

--- a/blog.tsx
+++ b/blog.tsx
@@ -35,11 +35,7 @@ import type {
   Post,
 } from "./types.d.ts";
 
-html.use(UnoCSS());
-
 export { Fragment, h };
-
-html.use(UnoCSS());
 
 const IS_DEV = Deno.args.includes("--dev") && "watchFs" in Deno;
 const POSTS = new Map<string, Post>();
@@ -97,6 +93,9 @@ function hmrSocket(callback) {
  * ```
  */
 export default async function blog(settings?: BlogSettings) {
+
+  html.use(UnoCSS(settings.unocss)); // Load custom unocss module if provided
+
   const url = callsites()[1].getFileName()!;
   const blogState = await configureBlog(url, IS_DEV, settings);
 

--- a/blog.tsx
+++ b/blog.tsx
@@ -93,7 +93,6 @@ function hmrSocket(callback) {
  * ```
  */
 export default async function blog(settings?: BlogSettings) {
-
   html.use(UnoCSS(settings.unocss)); // Load custom unocss module if provided
 
   const url = callsites()[1].getFileName()!;

--- a/deps.ts
+++ b/deps.ts
@@ -32,3 +32,5 @@ export { default as removeMarkdown } from "https://esm.sh/remove-markdown@0.5.0"
 
 // Add syntax highlighting support for C by default
 import "https://esm.sh/prismjs@1.28.0/components/prism-c?no-check";
+
+export type { UserConfig as UnoConfig } from "https://esm.sh/@unocss/core@0.43.2";

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,7 +30,7 @@ export interface BlogSettings {
   lang?: string;
   timezone?: string;
   canonicalUrl?: string;
-  unocss?: any // "object"
+  unocss?: any; // "object"
 }
 
 export interface BlogState extends BlogSettings {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,6 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-import type { ConnInfo, VNode } from "./deps.ts";
+import type { ConnInfo, UnoConfig, VNode } from "./deps.ts";
 
 export interface BlogContext {
   state: BlogState;
@@ -30,7 +30,7 @@ export interface BlogSettings {
   lang?: string;
   timezone?: string;
   canonicalUrl?: string;
-  unocss?: any; // "object"
+  unocss?: UnoConfig;
 }
 
 export interface BlogState extends BlogSettings {

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,6 +30,7 @@ export interface BlogSettings {
   lang?: string;
   timezone?: string;
   canonicalUrl?: string;
+  unocss?: any // "object"
 }
 
 export interface BlogState extends BlogSettings {


### PR DESCRIPTION
With this PR, you can customize UnoCSS with presets and all the fun stuff.

Example, to change the font
```ts
// ./unocss.ts
import presetWebFonts from 'https://esm.sh/@unocss/preset-web-fonts@0.42.0'
import presetUno from 'https://esm.sh/@unocss/preset-uno@0.42.0'

export const UNOCSS_OPTS = {
  presets: [
    presetUno(),
    presetWebFonts({
      provider: 'google', // default provider
      fonts: {
        // these will extend the default theme
        sans: {
          name: 'Outfit',
          weights: ['100', '300', '400', '700'],
        },
        mono: ['Fira Code', 'Fira Mono:400,700'],
      },
    }),
  ],
  preflights: [
    {
      getCSS: ({ theme }) => `
        html {
          font-family: 'Outfit';
        }
      `
    }
  ]
}
```

```ts
// main.ts
// ...
import { UNOCSS_OPTS } from './unocss.ts'

blog({
  // ...
  unocss: UNOCSS_OPTS
})
```