### PR TITLE
feat: added `showHeaderOnPostPage` config && vscode lint setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "deno.enable": true,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "denoland.vscode-deno",
+  "files.eol": "\n"
+}

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ import blog, { h } from "https://deno.land/x/blog/blog.tsx";
 blog({
   title: "My Blog",
   header: <header>Your custom header</header>,
+  showHeaderOnPostPage: true // by default, the header will only show on home, set showHeaderOnPostPage to true to make it show on each post page
   section: <section>Your custom section</section>,
   footer: <footer>Your custom footer</footer>,
 });

--- a/components.tsx
+++ b/components.tsx
@@ -27,8 +27,8 @@ export function Index({ state, posts }: IndexProps) {
   for (const [_key, post] of posts.entries()) {
     postIndex.push(post);
   }
-  postIndex.sort((a, b) =>
-    (b.publishDate?.getTime() ?? 0) - (a.publishDate?.getTime() ?? 0)
+  postIndex.sort(
+    (a, b) => (b.publishDate?.getTime() ?? 0) - (a.publishDate?.getTime() ?? 0),
   );
 
   return (
@@ -46,7 +46,9 @@ export function Index({ state, posts }: IndexProps) {
                 class={[
                   "bg-cover bg-center bg-no-repeat w-25 h-25 border-4 border-white",
                   state.avatarClass ?? "rounded-full",
-                ].filter(Boolean).join(" ")}
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
                 style={{ backgroundImage: `url(${state.avatar})` }}
               />
             )}
@@ -124,9 +126,7 @@ function PostCard({ post, timezone }: { post: Post; timezone: string }) {
       <p class="text-gray-500/80">
         <PrettyDate date={post.publishDate} timezone={timezone} />
       </p>
-      <p class="mt-3 text-gray-600 dark:text-gray-400">
-        {post.snippet}
-      </p>
+      <p class="mt-3 text-gray-600 dark:text-gray-400">{post.snippet}</p>
       <p class="mt-3">
         <a
           class="leading-tight text-gray-900 dark:text-gray-100 inline-block border-b-1 border-gray-600 hover:text-gray-500 hover:border-gray-500 transition-colors"
@@ -148,57 +148,58 @@ interface PostPageProps {
 export function PostPage({ post, state }: PostPageProps) {
   const html = gfm.render(post.markdown);
   return (
-    <div class="max-w-screen-sm px-6 pt-8 mx-auto">
-      <div class="pb-16">
-        <a
-          href="/"
-          class="inline-flex items-center gap-1 text-sm text-gray-500/80 hover:text-gray-700 transition-colors"
-          title="Back to Index Page"
-        >
-          <svg
-            className="inline-block w-5 h-5"
-            viewBox="0 0 20 20"
-            xmlns="http://www.w3.org/2000/svg"
+    <Fragment>
+      {state.showHeaderOnPostPage && state.header}
+      <div class="max-w-screen-sm px-6 pt-8 mx-auto">
+        <div class="pb-16">
+          <a
+            href="/"
+            class="inline-flex items-center gap-1 text-sm text-gray-500/80 hover:text-gray-700 transition-colors"
+            title="Back to Index Page"
           >
-            <path
-              d="M6.91675 14.4167L3.08341 10.5833C3.00008 10.5 2.94119 10.4097 2.90675 10.3125C2.87175 10.2153 2.85425 10.1111 2.85425 10C2.85425 9.88889 2.87175 9.78472 2.90675 9.6875C2.94119 9.59028 3.00008 9.5 3.08341 9.41667L6.93758 5.5625C7.09036 5.40972 7.27786 5.33334 7.50008 5.33334C7.7223 5.33334 7.91675 5.41667 8.08341 5.58334C8.23619 5.73611 8.31258 5.93056 8.31258 6.16667C8.31258 6.40278 8.23619 6.59722 8.08341 6.75L5.66675 9.16667H16.6667C16.9029 9.16667 17.1006 9.24639 17.2601 9.40584C17.4201 9.56584 17.5001 9.76389 17.5001 10C17.5001 10.2361 17.4201 10.4339 17.2601 10.5933C17.1006 10.7533 16.9029 10.8333 16.6667 10.8333H5.66675L8.10425 13.2708C8.25703 13.4236 8.33341 13.6111 8.33341 13.8333C8.33341 14.0556 8.25008 14.25 8.08341 14.4167C7.93064 14.5694 7.73619 14.6458 7.50008 14.6458C7.26397 14.6458 7.06953 14.5694 6.91675 14.4167Z"
-              fill="currentColor"
-            />
-          </svg>
-          INDEX
-        </a>
+            <svg
+              className="inline-block w-5 h-5"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6.91675 14.4167L3.08341 10.5833C3.00008 10.5 2.94119 10.4097 2.90675 10.3125C2.87175 10.2153 2.85425 10.1111 2.85425 10C2.85425 9.88889 2.87175 9.78472 2.90675 9.6875C2.94119 9.59028 3.00008 9.5 3.08341 9.41667L6.93758 5.5625C7.09036 5.40972 7.27786 5.33334 7.50008 5.33334C7.7223 5.33334 7.91675 5.41667 8.08341 5.58334C8.23619 5.73611 8.31258 5.93056 8.31258 6.16667C8.31258 6.40278 8.23619 6.59722 8.08341 6.75L5.66675 9.16667H16.6667C16.9029 9.16667 17.1006 9.24639 17.2601 9.40584C17.4201 9.56584 17.5001 9.76389 17.5001 10C17.5001 10.2361 17.4201 10.4339 17.2601 10.5933C17.1006 10.7533 16.9029 10.8333 16.6667 10.8333H5.66675L8.10425 13.2708C8.25703 13.4236 8.33341 13.6111 8.33341 13.8333C8.33341 14.0556 8.25008 14.25 8.08341 14.4167C7.93064 14.5694 7.73619 14.6458 7.50008 14.6458C7.26397 14.6458 7.06953 14.5694 6.91675 14.4167Z"
+                fill="currentColor"
+              />
+            </svg>
+            INDEX
+          </a>
+        </div>
+        {post.coverHtml && (
+          <div
+            class="pb-12"
+            dangerouslySetInnerHTML={{ __html: post.coverHtml }}
+          />
+        )}
+        <article>
+          <h1 class="text-4xl text-gray-900 dark:text-gray-100 font-bold">
+            {post.title}
+          </h1>
+          <p class="mt-1 text-gray-500">
+            {(state.author || post.author) && (
+              <span>By {state.author || post.author} at</span>
+            )}
+            <PrettyDate date={post.publishDate} timezone={state.timezone} />
+          </p>
+          <div
+            class="mt-8 markdown-body"
+            data-color-mode="auto"
+            data-light-theme="light"
+            data-dark-theme="dark"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </article>
+
+        {state.section}
+
+        {state.footer || <Footer author={state.author} />}
       </div>
-      {post.coverHtml && (
-        <div
-          class="pb-12"
-          dangerouslySetInnerHTML={{ __html: post.coverHtml }}
-        />
-      )}
-      <article>
-        <h1 class="text-4xl text-gray-900 dark:text-gray-100 font-bold">
-          {post.title}
-        </h1>
-        <p class="mt-1 text-gray-500">
-          {(state.author || post.author) && (
-            <span>
-              By {state.author || post.author} at {" "}
-            </span>
-          )}
-          <PrettyDate date={post.publishDate} timezone={state.timezone} />
-        </p>
-        <div
-          class="mt-8 markdown-body"
-          data-color-mode="auto"
-          data-light-theme="light"
-          data-dark-theme="dark"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      </article>
-
-      {state.section}
-
-      {state.footer || <Footer author={state.author} />}
-    </div>
+    </Fragment>
   );
 }
 
@@ -228,9 +229,7 @@ function Footer(props: { author?: string }) {
   );
 }
 
-function Tooltip(
-  { children }: { children: string },
-) {
+function Tooltip({ children }: { children: string }) {
   return (
     <div
       className={"absolute top-10 px-3 h-8 !leading-8 bg-black/80 text-white text-sm rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity"}

--- a/types.d.ts
+++ b/types.d.ts
@@ -13,18 +13,18 @@ export interface BlogMiddleware {
 }
 
 export interface BlogSettings {
-  title?: string | VNode;
-  description?: string | VNode;
+  title?: string;
+  description?: string;
   avatar?: string;
   avatarClass?: string;
   cover?: string;
   coverTextColor?: string;
   author?: string;
   links?: { title: string; url: string; icon?: VNode }[];
-  header?: string | VNode;
+  header?: VNode;
   showHeaderOnPostPage?: boolean;
-  section?: string | VNode;
-  footer?: string | VNode;
+  section?: VNode;
+  footer?: VNode;
   style?: string;
   ogImage?: string;
   middlewares?: BlogMiddleware[];

--- a/types.d.ts
+++ b/types.d.ts
@@ -13,17 +13,18 @@ export interface BlogMiddleware {
 }
 
 export interface BlogSettings {
-  title?: string;
-  description?: string;
+  title?: string | VNode;
+  description?: string | VNode;
   avatar?: string;
   avatarClass?: string;
   cover?: string;
   coverTextColor?: string;
   author?: string;
   links?: { title: string; url: string; icon?: VNode }[];
-  header?: VNode;
-  section?: VNode;
-  footer?: VNode;
+  header?: string | VNode;
+  showHeaderOnPostPage?: boolean;
+  section?: string | VNode;
+  footer?: string | VNode;
   style?: string;
   ogImage?: string;
   middlewares?: BlogMiddleware[];


### PR DESCRIPTION
There are 2 things in this PR:

1. added `showHeaderOnPostPage` config, because by default, the header will only show on home page, setting showHeaderOnPostPage to true will make it show on each post page
2. set up the `.vscode/settings.yml` so developers can have the "format on save" experience with deno's built-in TS linter (please make sure update your vscode to latest, and/or restart your deno language server in vscode)