### PR TITLE
feat & fix: `favicon`, `dateStyle` & missing space between author name and date

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ blog({
     { title: "Twitter", url: "https://twitter.com/denobot" },
   ],
   lang: "en",
-  timezone: "en-US",
+  dateFormat: "ll", // localised format based on https://day.js.org/docs/en/display/format#list-of-localized-formats
   middlewares: [
     ga("UA-XXXXXXXX-X"),
     redirects({

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ blog({
     }),
   ],
   unocss: unocss_opts, // check https://github.com/unocss/unocss
+  favicon: "favicon.ico",
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ blog({
     { title: "Twitter", url: "https://twitter.com/denobot" },
   ],
   lang: "en",
-  dateFormat: "ll", // localised format based on https://day.js.org/docs/en/display/format#list-of-localized-formats
+  dateStyle: "long", // localised format based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat
   middlewares: [
     ga("UA-XXXXXXXX-X"),
     redirects({

--- a/blog.tsx
+++ b/blog.tsx
@@ -17,6 +17,7 @@ import {
   gfm,
   h,
   html,
+  HtmlOptions,
   join,
   relative,
   removeMarkdown,
@@ -285,10 +286,27 @@ export async function handler(
     }
   }
 
+  const sharedHtmlOptions: HtmlOptions = {
+    colorScheme: blogState.theme ?? "auto",
+    lang: blogState.lang,
+    scripts: IS_DEV ? [{ src: "/hmr.js" }] : undefined,
+    links: [
+      { href: canonicalUrl, rel: "canonical" },
+    ],
+  };
+
+  if (blogState.favicon) {
+    sharedHtmlOptions.links?.push({
+      href: blogState.favicon,
+      type: "image/x-icon",
+      rel: "icon",
+    });
+  }
+
   if (pathname === "/") {
     return html({
-      colorScheme: blogState.theme ?? "auto",
-      lang: blogState.lang,
+      colorScheme: sharedHtmlOptions.colorScheme,
+      lang: sharedHtmlOptions.lang,
       title: blogState.title ?? "My Blog",
       meta: {
         "description": blogState.description,
@@ -300,13 +318,11 @@ export async function handler(
         "twitter:image": blogState.ogImage ?? blogState.cover,
         "twitter:card": blogState.ogImage ? "summary_large_image" : undefined,
       },
-      links: [
-        { href: canonicalUrl, rel: "canonical" },
-      ],
       styles: [
         ...(blogState.style ? [blogState.style] : []),
       ],
-      scripts: IS_DEV ? [{ src: "/hmr.js" }] : undefined,
+      links: sharedHtmlOptions.links,
+      scripts: sharedHtmlOptions.scripts,
       body: (
         <Index
           state={blogState}
@@ -319,8 +335,8 @@ export async function handler(
   const post = POSTS.get(pathname);
   if (post) {
     return html({
-      colorScheme: blogState.theme ?? "auto",
-      lang: blogState.lang,
+      colorScheme: sharedHtmlOptions.colorScheme,
+      lang: sharedHtmlOptions.lang,
       title: post.title,
       meta: {
         "description": post.snippet,
@@ -337,10 +353,8 @@ export async function handler(
         `.markdown-body { --color-canvas-default: transparent !important; --color-canvas-subtle: #edf0f2; --color-border-muted: rgba(128,128,128,0.2); } .markdown-body img + p { margin-top: 16px; }`,
         ...(blogState.style ? [blogState.style] : []),
       ],
-      links: [
-        { href: `${canonicalUrl}${pathname}`, rel: "canonical" },
-      ],
-      scripts: IS_DEV ? [{ src: "/hmr.js" }] : undefined,
+      links: sharedHtmlOptions.links,
+      scripts: sharedHtmlOptions.scripts,
       body: <PostPage post={post} state={blogState} />,
     });
   }

--- a/blog.tsx
+++ b/blog.tsx
@@ -9,6 +9,7 @@
 import {
   callsites,
   createReporter,
+  dayjs,
   dirname,
   Feed,
   Fragment,
@@ -99,6 +100,8 @@ export default async function blog(settings?: BlogSettings) {
   const url = callsites()[1].getFileName()!;
   const blogState = await configureBlog(url, IS_DEV, settings);
 
+  await configureDateLocale(settings?.lang);
+
   const blogHandler = createBlogHandler(blogState);
   serve(blogHandler);
 }
@@ -174,6 +177,18 @@ export async function configureBlog(
   await loadContent(directory, isDev);
 
   return state;
+}
+
+export async function configureDateLocale(lang = "en") {
+  try {
+    await import(
+      `https://esm.sh/dayjs@1.11.3/locale/${lang}`
+    );
+    dayjs.locale(lang);
+  } catch {
+    await import("https://esm.sh/dayjs@1.11.3/locale/en");
+    dayjs.locale("en");
+  }
 }
 
 async function loadContent(blogDirectory: string, isDev: boolean) {

--- a/blog_test.ts
+++ b/blog_test.ts
@@ -1,6 +1,11 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-import { configureBlog, createBlogHandler, redirects } from "./blog.tsx";
+import {
+  configureBlog,
+  configureDateLocale,
+  createBlogHandler,
+  redirects,
+} from "./blog.tsx";
 import {
   assert,
   assertEquals,
@@ -14,6 +19,8 @@ const SETTINGS = {
   author: "The author",
   title: "Test blog",
   description: "This is some description.",
+  lang: "zh",
+  dateFormat: "ll",
   middlewares: [
     redirects({
       "/to_second": "second",
@@ -23,6 +30,7 @@ const SETTINGS = {
   ],
 };
 const BLOG_SETTINGS = await configureBlog(BLOG_URL, false, SETTINGS);
+await configureDateLocale(BLOG_SETTINGS.lang);
 const CONN_INFO = {
   localAddr: {
     transport: "tcp" as const,
@@ -47,7 +55,7 @@ Deno.test("index page", async () => {
   assertEquals(resp.status, 200);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
   const body = await resp.text();
-  assertStringIncludes(body, `<html lang="en">`);
+  assertStringIncludes(body, `<html lang="zh">`);
   assertStringIncludes(body, `Test blog`);
   assertStringIncludes(body, `This is some description.`);
   assertStringIncludes(body, `href="/first"`);
@@ -60,10 +68,14 @@ Deno.test("posts/ first", async () => {
   assertEquals(resp.status, 200);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
   const body = await resp.text();
-  assertStringIncludes(body, `<html lang="en">`);
+  assertStringIncludes(body, `<html lang="zh">`);
   assertStringIncludes(body, `First post`);
-  assertStringIncludes(body, `The author`);
-  assertStringIncludes(body, `2022-03-20`);
+  assertStringIncludes(body, `By The author`);
+  assertStringIncludes(body, `© ${new Date().getFullYear()} The author`);
+  assertStringIncludes(
+    body,
+    `<time dateTime="2022-03-20T00:00:00.000Z">2022年3月20日</time>`,
+  );
   assertStringIncludes(body, `<img src="first/hello.png" />`);
   assertStringIncludes(body, `<p>Lorem Ipsum is simply dummy text`);
   assertStringIncludes(body, `$100, $200, $300, $400, $500`);
@@ -75,10 +87,14 @@ Deno.test("posts/ second", async () => {
   assertEquals(resp.status, 200);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
   const body = await resp.text();
-  assertStringIncludes(body, `<html lang="en">`);
+  assertStringIncludes(body, `<html lang="zh">`);
   assertStringIncludes(body, `Second post`);
-  assertStringIncludes(body, `The author`);
-  assertStringIncludes(body, `2022-05-02`);
+  assertStringIncludes(body, `By CUSTOM AUTHOR NAME`);
+  assertStringIncludes(body, `© ${new Date().getFullYear()} The author`);
+  assertStringIncludes(
+    body,
+    `<time dateTime="2022-05-02T00:00:00.000Z">2022年5月2日</time>`,
+  );
   assertStringIncludes(body, `<img src="second/hello2.png" />`);
   assertStringIncludes(body, `<p>Lorem Ipsum is simply dummy text`);
 });

--- a/blog_test.ts
+++ b/blog_test.ts
@@ -1,11 +1,6 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-import {
-  configureBlog,
-  configureDateLocale,
-  createBlogHandler,
-  redirects,
-} from "./blog.tsx";
+import { configureBlog, createBlogHandler, redirects } from "./blog.tsx";
 import {
   assert,
   assertEquals,
@@ -15,12 +10,12 @@ import { fromFileUrl, join } from "https://deno.land/std@0.140.0/path/mod.ts";
 
 const BLOG_URL = new URL("./testdata/main.js", import.meta.url).href;
 const TESTDATA_PATH = fromFileUrl(new URL("./testdata/", import.meta.url));
-const SETTINGS = {
+const BLOG_SETTINGS = await configureBlog(BLOG_URL, false, {
   author: "The author",
   title: "Test blog",
   description: "This is some description.",
-  lang: "zh",
-  dateFormat: "ll",
+  lang: "en-GB",
+  dateStyle: "medium",
   middlewares: [
     redirects({
       "/to_second": "second",
@@ -28,9 +23,7 @@ const SETTINGS = {
       "second.html": "second",
     }),
   ],
-};
-const BLOG_SETTINGS = await configureBlog(BLOG_URL, false, SETTINGS);
-await configureDateLocale(BLOG_SETTINGS.lang);
+});
 const CONN_INFO = {
   localAddr: {
     transport: "tcp" as const,
@@ -55,7 +48,7 @@ Deno.test("index page", async () => {
   assertEquals(resp.status, 200);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
   const body = await resp.text();
-  assertStringIncludes(body, `<html lang="zh">`);
+  assertStringIncludes(body, `<html lang="en-GB">`);
   assertStringIncludes(body, `Test blog`);
   assertStringIncludes(body, `This is some description.`);
   assertStringIncludes(body, `href="/first"`);
@@ -68,13 +61,13 @@ Deno.test("posts/ first", async () => {
   assertEquals(resp.status, 200);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
   const body = await resp.text();
-  assertStringIncludes(body, `<html lang="zh">`);
+  assertStringIncludes(body, `<html lang="en-GB">`);
   assertStringIncludes(body, `First post`);
   assertStringIncludes(body, `By The author`);
   assertStringIncludes(body, `© ${new Date().getFullYear()} The author`);
   assertStringIncludes(
     body,
-    `<time dateTime="2022-03-20T00:00:00.000Z">2022年3月20日</time>`,
+    `<time dateTime="2022-03-20T00:00:00.000Z">20 Mar 2022</time>`,
   );
   assertStringIncludes(body, `<img src="first/hello.png" />`);
   assertStringIncludes(body, `<p>Lorem Ipsum is simply dummy text`);
@@ -87,13 +80,13 @@ Deno.test("posts/ second", async () => {
   assertEquals(resp.status, 200);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
   const body = await resp.text();
-  assertStringIncludes(body, `<html lang="zh">`);
+  assertStringIncludes(body, `<html lang="en-GB">`);
   assertStringIncludes(body, `Second post`);
   assertStringIncludes(body, `By CUSTOM AUTHOR NAME`);
   assertStringIncludes(body, `© ${new Date().getFullYear()} The author`);
   assertStringIncludes(
     body,
-    `<time dateTime="2022-05-02T00:00:00.000Z">2022年5月2日</time>`,
+    `<time dateTime="2022-05-02T00:00:00.000Z">2 May 2022</time>`,
   );
   assertStringIncludes(body, `<img src="second/hello2.png" />`);
   assertStringIncludes(body, `<p>Lorem Ipsum is simply dummy text`);

--- a/components.tsx
+++ b/components.tsx
@@ -7,8 +7,8 @@
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-import { dayjs, Fragment, gfm, h } from "./deps.ts";
-import type { BlogState, Post } from "./types.d.ts";
+import { Fragment, gfm, h } from "./deps.ts";
+import type { BlogState, DateStyle, Post } from "./types.d.ts";
 
 const socialAppIcons = new Map([
   ["github.com", IconGithub],
@@ -105,7 +105,8 @@ export function Index({ state, posts }: IndexProps) {
             <PostCard
               post={post}
               key={post.pathname}
-              dateFormat={state.dateFormat}
+              dateStyle={state.dateStyle}
+              lang={state.lang}
             />
           ))}
         </div>
@@ -116,7 +117,13 @@ export function Index({ state, posts }: IndexProps) {
   );
 }
 
-function PostCard({ post, dateFormat }: { post: Post; dateFormat?: string }) {
+function PostCard(
+  { post, dateStyle, lang }: {
+    post: Post;
+    dateStyle?: DateStyle;
+    lang?: string;
+  },
+) {
   return (
     <div class="pt-12 first:pt-0">
       <h3 class="text-2xl font-bold">
@@ -130,7 +137,8 @@ function PostCard({ post, dateFormat }: { post: Post; dateFormat?: string }) {
           <span>By {post.author || ""} at{" "}</span>}
         <PrettyDate
           date={post.publishDate}
-          dateFormat={dateFormat}
+          dateStyle={dateStyle}
+          lang={lang}
         />
       </p>
       <p class="mt-3 text-gray-600 dark:text-gray-400">{post.snippet}</p>
@@ -194,7 +202,8 @@ export function PostPage({ post, state }: PostPageProps) {
             )}
             <PrettyDate
               date={post.publishDate}
-              dateFormat={state.dateFormat}
+              dateStyle={state.dateStyle}
+              lang={state.lang}
             />
           </p>
           <div
@@ -268,8 +277,14 @@ function Tooltip({ children }: { children: string }) {
   );
 }
 
-function PrettyDate({ date, dateFormat }: { date: Date; dateFormat?: string }) {
-  const formatted = dayjs(date).format(dateFormat ?? "M/D/YYYY");
+function PrettyDate(
+  { date, dateStyle, lang }: {
+    date: Date;
+    dateStyle?: DateStyle;
+    lang?: string;
+  },
+) {
+  const formatted = date.toLocaleDateString(lang ?? "en-US", { dateStyle });
   return <time dateTime={date.toISOString()}>{formatted}</time>;
 }
 

--- a/components.tsx
+++ b/components.tsx
@@ -185,7 +185,7 @@ export function PostPage({ post, state }: PostPageProps) {
           <Tags tags={post.tags} />
           <p class="mt-1 text-gray-500">
             {(state.author || post.author) && (
-              <span>By {state.author || post.author} at</span>
+              <span>By {state.author || post.author} at{" "}</span>
             )}
             <PrettyDate date={post.publishDate} timezone={state.timezone} />
           </p>

--- a/components.tsx
+++ b/components.tsx
@@ -7,7 +7,7 @@
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-import { Fragment, gfm, h, type VNode } from "./deps.ts";
+import { dayjs, Fragment, gfm, h } from "./deps.ts";
 import type { BlogState, Post } from "./types.d.ts";
 
 const socialAppIcons = new Map([
@@ -105,7 +105,7 @@ export function Index({ state, posts }: IndexProps) {
             <PostCard
               post={post}
               key={post.pathname}
-              timezone={state.timezone ?? "en-US"}
+              dateFormat={state.dateFormat}
             />
           ))}
         </div>
@@ -116,9 +116,7 @@ export function Index({ state, posts }: IndexProps) {
   );
 }
 
-function PostCard(
-  { post, timezone }: { post: Post; timezone: string },
-) {
+function PostCard({ post, dateFormat }: { post: Post; dateFormat?: string }) {
   return (
     <div class="pt-12 first:pt-0">
       <h3 class="text-2xl font-bold">
@@ -130,7 +128,10 @@ function PostCard(
       <p class="text-gray-500/80">
         {(post.author) &&
           <span>By {post.author || ""} at{" "}</span>}
-        <PrettyDate date={post.publishDate} timezone={timezone} />
+        <PrettyDate
+          date={post.publishDate}
+          dateFormat={dateFormat}
+        />
       </p>
       <p class="mt-3 text-gray-600 dark:text-gray-400">{post.snippet}</p>
       <p class="mt-3">
@@ -191,7 +192,10 @@ export function PostPage({ post, state }: PostPageProps) {
             {(post.author || state.author) && (
               <span>By {post.author || state.author} at{" "}</span>
             )}
-            <PrettyDate date={post.publishDate} timezone={state.timezone} />
+            <PrettyDate
+              date={post.publishDate}
+              dateFormat={state.dateFormat}
+            />
           </p>
           <div
             class="mt-8 markdown-body"
@@ -264,8 +268,8 @@ function Tooltip({ children }: { children: string }) {
   );
 }
 
-function PrettyDate({ date, timezone }: { date: Date; timezone?: string }) {
-  const formatted = date.toLocaleDateString(timezone ?? "en-US");
+function PrettyDate({ date, dateFormat }: { date: Date; dateFormat?: string }) {
+  const formatted = dayjs(date).format(dateFormat ?? "M/D/YYYY");
   return <time dateTime={date.toISOString()}>{formatted}</time>;
 }
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,5 +1,6 @@
 {
   "tasks": {
+    "demo": "deno run  --allow-net --allow-read --allow-env=NODE_DEBUG --watch --no-check testdata/my_blog.ts --dev",
     "test": "deno test --no-check=remote --allow-read"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "tasks": {
     "demo": "deno run  --allow-net --allow-read --allow-env=NODE_DEBUG --watch --no-check testdata/my_blog.ts --dev",
-    "test": "deno test --no-check=remote --allow-read"
+    "test": "deno test --no-check=remote --allow-read --allow-net"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "tasks": {
     "demo": "deno run  --allow-net --allow-read --allow-env=NODE_DEBUG --watch --no-check testdata/my_blog.ts --dev",
-    "test": "deno test --no-check=remote --allow-read --allow-net"
+    "test": "deno test --no-check=remote --allow-read"
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -18,6 +18,7 @@ export {
   Fragment,
   h,
   html,
+  type HtmlOptions,
   type VNode,
 } from "https://deno.land/x/htm@0.0.10/mod.tsx";
 import { UnoCSS } from "https://deno.land/x/htm@0.0.10/plugins.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -39,8 +39,3 @@ export type UnoConfig = typeof UnoCSS extends (
   arg: infer P | undefined,
 ) => unknown ? P
   : never;
-
-import dayjs from "https://esm.sh/dayjs@1.11.3";
-import localizedFormat from "https://esm.sh/dayjs@1.11.3/plugin/localizedFormat";
-dayjs.extend(localizedFormat);
-export { dayjs };

--- a/deps.ts
+++ b/deps.ts
@@ -39,3 +39,8 @@ export type UnoConfig = typeof UnoCSS extends (
   arg: infer P | undefined,
 ) => unknown ? P
   : never;
+
+import dayjs from "https://esm.sh/dayjs@1.11.3";
+import localizedFormat from "https://esm.sh/dayjs@1.11.3/plugin/localizedFormat";
+dayjs.extend(localizedFormat);
+export { dayjs };

--- a/testdata/posts/second.md
+++ b/testdata/posts/second.md
@@ -1,6 +1,6 @@
 ---
 title: Second post
-author: author 2
+author: CUSTOM AUTHOR NAME
 publish_date: 2022-05-02
 abstract: This is the second post.
 ---

--- a/types.d.ts
+++ b/types.d.ts
@@ -12,6 +12,8 @@ export interface BlogMiddleware {
   (req: Request, ctx: BlogContext): Promise<Response>;
 }
 
+export type DateStyle = "full" | "long" | "medium" | "short";
+
 export interface BlogSettings {
   title?: string;
   description?: string;
@@ -29,7 +31,7 @@ export interface BlogSettings {
   ogImage?: string;
   middlewares?: BlogMiddleware[];
   lang?: string;
-  dateFormat?: string;
+  dateStyle?: DateStyle;
   canonicalUrl?: string;
   unocss?: UnoConfig;
   theme?: "dark" | "light" | "auto";

--- a/types.d.ts
+++ b/types.d.ts
@@ -33,6 +33,7 @@ export interface BlogSettings {
   canonicalUrl?: string;
   unocss?: UnoConfig;
   theme?: "dark" | "light" | "auto";
+  favicon?: string;
 }
 
 export interface BlogState extends BlogSettings {

--- a/types.d.ts
+++ b/types.d.ts
@@ -29,7 +29,7 @@ export interface BlogSettings {
   ogImage?: string;
   middlewares?: BlogMiddleware[];
   lang?: string;
-  timezone?: string;
+  dateFormat?: string;
   canonicalUrl?: string;
   unocss?: UnoConfig;
   theme?: "dark" | "light" | "auto";


### PR DESCRIPTION
This PR does 4 things:

1. allow users to put custom favicon
2. allow configure `dateStyle` with localized date format based on [Intl.DateTimeFormat()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#syntax) , and removed `timezone`
3. fixed https://github.com/denoland/deno_blog/issues/39
4. add a shortcut to run testdata project locally by running `deno task demo` 
