### PR TITLE
Fix: init bugs & theme related bugs on post content

### DIFF
--- a/components.tsx
+++ b/components.tsx
@@ -208,7 +208,7 @@ export function PostPage({ post, state }: PostPageProps) {
           </p>
           <div
             class="mt-8 markdown-body"
-            data-color-mode="auto"
+            data-color-mode={state.theme ?? "auto"}
             data-light-theme="light"
             data-dark-theme="dark"
             dangerouslySetInnerHTML={{ __html: html }}

--- a/init.ts
+++ b/init.ts
@@ -40,7 +40,6 @@ blog({
   avatar: "https://deno-avatar.deno.dev/avatar/blog.svg",
   avatarClass: "rounded-full",
   author: "An author",
-  background: "#f9f9f9",
 
   // middlewares: [
 

--- a/testdata/posts/first.md
+++ b/testdata/posts/first.md
@@ -31,7 +31,6 @@ blog({
   description: "The blog description.",
   avatar: "https://deno-avatar.deno.dev/avatar/blog.svg",
   avatarClass: "rounded-full",
-  background: "#f9f9f9",
   links: [
     { title: "Email", url: "mailto:bot@deno.com" },
     { title: "GitHub", url: "https://github.com/denobot" },

--- a/types.d.ts
+++ b/types.d.ts
@@ -51,7 +51,6 @@ export interface Post {
   author?: string;
   snippet?: string;
   coverHtml?: string;
-  background?: string;
   /** An image URL which is used in the OpenGraph og:image tag. */
   ogImage?: string;
   tags?: string[];


### PR DESCRIPTION
Can we release this PR soon (maybe in 0.4.1?) because 2 things are broken right now in 0.4.0

1. The init command will add `background` to the setting, but this setting was already removed since the dark mode is introduced
2. When user agent is in dark mode, and the state is in light mode, the post content text will still be displayed in dark mode color because the setting is not read properly for post content's `data-color-mode`