### PR TITLE
feat: tag each page with custom classname

### DIFF
--- a/components.tsx
+++ b/components.tsx
@@ -32,7 +32,7 @@ export function Index({ state, posts }: IndexProps) {
   );
 
   return (
-    <>
+    <div class="home">
       {state.header || (
         <header
           class="w-full h-90 lt-sm:h-80 bg-cover bg-center bg-no-repeat"
@@ -113,7 +113,7 @@ export function Index({ state, posts }: IndexProps) {
 
         {state.footer || <Footer author={state.author} />}
       </div>
-    </>
+    </div>
   );
 }
 
@@ -163,7 +163,7 @@ interface PostPageProps {
 export function PostPage({ post, state }: PostPageProps) {
   const html = gfm.render(post.markdown);
   return (
-    <Fragment>
+    <div className={`post ${post.pathname.substring(1)}`}>
       {state.showHeaderOnPostPage && state.header}
       <div class="max-w-screen-sm px-6 pt-8 mx-auto">
         <div class="pb-16">
@@ -219,7 +219,7 @@ export function PostPage({ post, state }: PostPageProps) {
 
         {state.footer || <Footer author={state.author} />}
       </div>
-    </Fragment>
+    </div>
   );
 }
 


### PR DESCRIPTION
Currently each post page and the home page has same dom structure, so there is no way to add page specific css selectors to apply page specific styles

This pr adds a page specific classname and a surrouding div to the page content

So with this setup below

<img width="463" alt="image" src="https://user-images.githubusercontent.com/28719400/178527399-79e9cca5-eae6-4dbf-a8a4-d6376cd025f8.png">

We can hide certain text on post pages, or home page or even a specific post page

| Home page | Post page |
| --- | --- |
| <img width="985" alt="image" src="https://user-images.githubusercontent.com/28719400/178527467-a8c9d431-178f-46c1-a78e-767593929a4d.png"> | <img width="984" alt="image" src="https://user-images.githubusercontent.com/28719400/178527523-3589ef91-800d-49c5-857c-27a2332c4ad6.png"> |