### PR TITLE
feat: add default front matter support

### DIFF
--- a/blog.tsx
+++ b/blog.tsx
@@ -265,7 +265,7 @@ async function loadPost(
     markdown: body,
     coverHtml: data.get("cover_html") ?? defaultFrontMatter?.cover_html,
     ogImage: data.get("og:image") ?? defaultFrontMatter?.["og:image"],
-    tags: data.get("tags") ?? defaultFrontMatter?.tags,
+    tags: covertTagsToArray(data.get("tags") ?? defaultFrontMatter?.tags),
   };
   POSTS.set(pathname, post);
   console.log("Load: ", post.pathname);
@@ -536,4 +536,18 @@ function frontMatterToString(frontMatter: Record<string, unknown> = {}) {
   }).join("\n");
 
   return `${line}\n${attrs}\n${line}\n`;
+}
+
+function covertTagsToArray(tags: unknown): string[] {
+  switch (typeof tags) {
+    case "string":
+      return tags.split(",").map((value) => value.trim());
+    case "boolean":
+    case "number":
+      return [`${tags}`];
+    case "object":
+      return Array.isArray(tags) ? tags : [];
+    default:
+      return tags = [];
+  }
 }

--- a/blog.tsx
+++ b/blog.tsx
@@ -20,6 +20,7 @@ import {
   html,
   HtmlOptions,
   join,
+  normalize,
   relative,
   removeMarkdown,
   serve,
@@ -238,7 +239,7 @@ async function loadPost(
   const { body, attrs } = frontMatter<Record<string, unknown>>(contents);
 
   const data = recordGetter(attrs);
-  
+
   let snippet: string | undefined = data.get("snippet") ??
     data.get("abstract") ??
     data.get("summary") ??
@@ -257,7 +258,7 @@ async function loadPost(
     author: data.get("author") ?? defaultFrontMatter?.author,
     // Note: users can override path of a blog post using
     // pathname in front matter.
-    pathname: data.get("pathname") ?? pathname,
+    pathname: normalize(data.get("pathname") ?? pathname),
     publishDate: data.get("publish_date")
       ? new Date(data.get("publish_date")!)
       : new Date(lastModifiedDate),
@@ -267,7 +268,8 @@ async function loadPost(
     ogImage: data.get("og:image") ?? defaultFrontMatter?.["og:image"],
     tags: covertTagsToArray(data.get("tags") ?? defaultFrontMatter?.tags),
   };
-  POSTS.set(pathname, post);
+
+  POSTS.set(post.pathname, post);
   console.log("Load: ", post.pathname);
 }
 
@@ -352,7 +354,7 @@ export async function handler(
     });
   }
 
-  const post = POSTS.get(pathname);
+  const post = POSTS.get(normalize(decodeURI(pathname)));
   if (post) {
     return html({
       ...sharedHtmlOptions,

--- a/deps.ts
+++ b/deps.ts
@@ -1,18 +1,21 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-export { serveDir } from "https://deno.land/std@0.149.0/http/file_server.ts";
-export { walk } from "https://deno.land/std@0.149.0/fs/walk.ts";
+export { serveDir } from "https://deno.land/std@0.151.0/http/file_server.ts";
+export { walk } from "https://deno.land/std@0.151.0/fs/walk.ts";
 export {
   dirname,
   fromFileUrl,
   join,
   relative,
-} from "https://deno.land/std@0.149.0/path/mod.ts";
+} from "https://deno.land/std@0.151.0/path/mod.ts";
 export {
   type ConnInfo,
   serve,
-} from "https://deno.land/std@0.149.0/http/mod.ts";
-export { extract as frontMatter } from "https://deno.land/std@0.149.0/encoding/front_matter.ts";
+} from "https://deno.land/std@0.151.0/http/mod.ts";
+export {
+  test as hasFrontMatter,
+  extract as frontMatter,
+} from "https://deno.land/std@0.151.0/encoding/front_matter.ts";
 
 export * as gfm from "https://deno.land/x/gfm@0.1.22/mod.ts";
 export {

--- a/deps.ts
+++ b/deps.ts
@@ -6,6 +6,7 @@ export {
   dirname,
   fromFileUrl,
   join,
+  normalize,
   relative,
 } from "https://deno.land/std@0.151.0/path/mod.ts";
 export {
@@ -13,8 +14,8 @@ export {
   serve,
 } from "https://deno.land/std@0.151.0/http/mod.ts";
 export {
-  test as hasFrontMatter,
   extract as frontMatter,
+  test as hasFrontMatter,
 } from "https://deno.land/std@0.151.0/encoding/front_matter.ts";
 
 export * as gfm from "https://deno.land/x/gfm@0.1.22/mod.ts";

--- a/types.d.ts
+++ b/types.d.ts
@@ -14,6 +14,20 @@ export interface BlogMiddleware {
 
 export type DateStyle = "full" | "long" | "medium" | "short";
 
+export interface FrontMatterOptions {
+  title?: string;
+  author?: string;
+  snippet?: string;
+  abstract?: string;
+  summary?: string;
+  description?: string;
+  pathname?: string;
+  publish_date?: string | Date;
+  cover_html?: string;
+  "og:image"?: string;
+  tags?: string[];
+}
+
 export interface BlogSettings {
   /** The blog title */
   title?: string;
@@ -73,6 +87,16 @@ export interface BlogSettings {
   port?: number;
   /** The hostname to serve the blog on */
   hostname?: string;
+  /** Default front matter setting */
+  defaultFrontMatter?: Omit<
+    FrontMatterOptions,
+    | "pathname"
+    | "publish_date"
+    | "snippet"
+    | "abstract"
+    | "summary"
+    | "description"
+  >;
 }
 
 export interface BlogState extends BlogSettings {


### PR DESCRIPTION
* Allow user to configure default front matter
* Wrap `data.get('publish_date')` with new Date to support JS Date Formats in the md file
* Set `publish_date` default to file's last modified date
* Convert `tags` to array to prevent `TypeError tags?.map is not a function` 
* normalize the file path (this use to support windows file path) & decode the URI (support non-English words url)
* Update dependencies to std@0.151