### PR TITLE
fix: catch error on loadPost when watch fs change

### DIFF
--- a/blog.tsx
+++ b/blog.tsx
@@ -204,13 +204,14 @@ async function watchForChanges(postsDirectory: string) {
     if (event.kind === "modify" || event.kind === "create") {
       for (const path of event.paths) {
         if (path.endsWith(".md")) {
-          await loadPost(postsDirectory, path).then(() => {
+          try {
+            await loadPost(postsDirectory, path);
             HMR_SOCKETS.forEach((socket) => {
               socket.send("refresh");
             });
-          }, (err) => {
+          } catch (err) {
             console.error(`loadPost ${path} error:`, err.message);
-          });
+          }
         }
       }
     }

--- a/blog.tsx
+++ b/blog.tsx
@@ -204,9 +204,12 @@ async function watchForChanges(postsDirectory: string) {
     if (event.kind === "modify" || event.kind === "create") {
       for (const path of event.paths) {
         if (path.endsWith(".md")) {
-          await loadPost(postsDirectory, path);
-          HMR_SOCKETS.forEach((socket) => {
-            socket.send("refresh");
+          await loadPost(postsDirectory, path).then(() => {
+            HMR_SOCKETS.forEach((socket) => {
+              socket.send("refresh");
+            });
+          }, (err) => {
+            console.error(`loadPost ${path} error:`, err.message);
           });
         }
       }


### PR DESCRIPTION
If there were errors when parse markdown file on loadPost it will break watchFs functional.