### PR TITLE
add support for light & dark favicons

### DIFF
--- a/blog.tsx
+++ b/blog.tsx
@@ -303,12 +303,30 @@ export async function handler(
     ],
   };
 
-  if (blogState.favicon) {
+  if (typeof blogState.favicon === "string") {
     sharedHtmlOptions.links?.push({
       href: blogState.favicon,
       type: "image/x-icon",
       rel: "icon",
     });
+  } else if (blogState.favicon) {
+    if (blogState.favicon.light) {
+      sharedHtmlOptions.links?.push({
+        href: blogState.favicon.light,
+        type: "image/x-icon",
+        media: "(prefers-color-scheme:light)",
+        rel: "icon",
+      });
+    }
+
+    if (blogState.favicon.dark) {
+      sharedHtmlOptions.links?.push({
+        href: blogState.favicon.dark,
+        type: "image/x-icon",
+        media: "(prefers-color-scheme:dark)",
+        rel: "icon",
+      });
+    }
   }
 
   if (pathname === "/") {

--- a/blog.tsx
+++ b/blog.tsx
@@ -309,8 +309,8 @@ export async function handler(
       type: "image/x-icon",
       rel: "icon",
     });
-  } else if (blogState.favicon) {
-    if (blogState.favicon.light) {
+  } else {
+    if (blogState.favicon?.light) {
       sharedHtmlOptions.links?.push({
         href: blogState.favicon.light,
         type: "image/x-icon",
@@ -319,7 +319,7 @@ export async function handler(
       });
     }
 
-    if (blogState.favicon.dark) {
+    if (blogState.favicon?.dark) {
       sharedHtmlOptions.links?.push({
         href: blogState.favicon.dark,
         type: "image/x-icon",

--- a/types.d.ts
+++ b/types.d.ts
@@ -67,7 +67,10 @@ export interface BlogSettings {
   unocss?: UnoConfig;
   /** Color scheme */
   theme?: "dark" | "light" | "auto";
-  /** URL to favicon. Can be relative. Supports dark and light mode variants through "prefers-color-scheme". */
+  /**
+   * URL to favicon. Can be relative.
+   * Supports dark and light mode variants through "prefers-color-scheme".
+   */
   favicon?: string | { light?: string; dark?: string };
   /** The port to serve the blog on */
   port?: number;

--- a/types.d.ts
+++ b/types.d.ts
@@ -67,8 +67,8 @@ export interface BlogSettings {
   unocss?: UnoConfig;
   /** Color scheme */
   theme?: "dark" | "light" | "auto";
-  /** URL to favicon. Can be relative. */
-  favicon?: string;
+  /** URL to favicon. Can be relative. Supports dark and light mode variants through "prefers-color-scheme". */
+  favicon?: string | { light?: string; dark?: string };
   /** The port to serve the blog on */
   port?: number;
   /** The hostname to serve the blog on */


### PR DESCRIPTION
This will let developers define different favicons based on the viewers [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) setting.

![gif](https://user-images.githubusercontent.com/21334130/184680002-e4657d85-927c-4ce0-89ac-b538e47cd639.gif)
