### PR TITLE
chore: update deno std library version

### DIFF
--- a/blog_test.ts
+++ b/blog_test.ts
@@ -5,8 +5,8 @@ import {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "https://deno.land/std@0.149.0/testing/asserts.ts";
-import { fromFileUrl, join } from "https://deno.land/std@0.149.0/path/mod.ts";
+} from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import { fromFileUrl, join } from "https://deno.land/std@0.153.0/path/mod.ts";
 
 const BLOG_URL = new URL("./testdata/main.js", import.meta.url).href;
 const TESTDATA_PATH = fromFileUrl(new URL("./testdata/", import.meta.url));

--- a/deps.ts
+++ b/deps.ts
@@ -1,18 +1,18 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-export { serveDir } from "https://deno.land/std@0.149.0/http/file_server.ts";
-export { walk } from "https://deno.land/std@0.149.0/fs/walk.ts";
+export { serveDir } from "https://deno.land/std@0.153.0/http/file_server.ts";
+export { walk } from "https://deno.land/std@0.153.0/fs/walk.ts";
 export {
   dirname,
   fromFileUrl,
   join,
   relative,
-} from "https://deno.land/std@0.149.0/path/mod.ts";
+} from "https://deno.land/std@0.153.0/path/mod.ts";
 export {
   type ConnInfo,
   serve,
-} from "https://deno.land/std@0.149.0/http/mod.ts";
-export { extract as frontMatter } from "https://deno.land/std@0.149.0/encoding/front_matter.ts";
+} from "https://deno.land/std@0.153.0/http/mod.ts";
+export { extract as frontMatter } from "https://deno.land/std@0.153.0/encoding/front_matter.ts";
 
 export * as gfm from "https://deno.land/x/gfm@0.1.22/mod.ts";
 export {

--- a/init.ts
+++ b/init.ts
@@ -1,6 +1,6 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-import { join, resolve } from "https://deno.land/std@0.149.0/path/mod.ts";
+import { join, resolve } from "https://deno.land/std@0.153.0/path/mod.ts";
 
 const HELP = `deno_blog
 


### PR DESCRIPTION
New is always better.

- [x] No tests are failing.
