### PR TITLE
feat: pass Post props to `section`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ blog({
   title: "My Blog",
   header: <header>Your custom header</header>,
   showHeaderOnPostPage: true, // by default, the header will only show on home, set showHeaderOnPostPage to true to make it show on each post page
-  section: <section>Your custom section</section>,
+  section: (post) => (
+    <section>Your custom section with access to Post props.</section>
+  ),
   footer: <footer>Your custom footer</footer>,
 });
 ```

--- a/components.tsx
+++ b/components.tsx
@@ -218,7 +218,7 @@ export function PostPage({ post, state }: PostPageProps) {
           />
         </article>
 
-        {state.section}
+        {state.section && state.section(post)}
 
         {state.footer || <Footer author={state.author} />}
       </div>

--- a/init.ts
+++ b/init.ts
@@ -37,7 +37,7 @@ blog({
   title: "My Blog",
   description: "This is my new blog.",
   // header: <header>Your custom header</header>,
-  // section: <section>Your custom section</section>,
+  // section: (post: Post) => <section>Your custom section with access to Post props.</section>,
   // footer: <footer>Your custom footer</footer>,
   avatar: "https://deno-avatar.deno.dev/avatar/blog.svg",
   avatarClass: "rounded-full",

--- a/types.d.ts
+++ b/types.d.ts
@@ -44,8 +44,8 @@ export interface BlogSettings {
   header?: VNode;
   /** Whether to show the header on post pages */
   showHeaderOnPostPage?: boolean;
-  /** The element to use as section */
-  section?: VNode;
+  /** The element to use as section. Access to Post props. */
+  section?: (post: Post) => VNode;
   /** The element to use as footer */
   footer?: VNode;
   /** Custom CSS */


### PR DESCRIPTION
I want to add a custom section to my posts for users to "Edit on GitHub". In order to make this link dynamic per page, I need access to the `post.pathname`. I can then pass `section` in the `BlogSettings` like, 

```jsx
section: (post) => (
    <span>
      <a href=`https://github.com/musab/blog/edit/main/posts${post.pathname}.md`>
        Edit on GitHub
      </a>
    </span>
  ),
```

First time contributing, open to any suggestions. I wanted to add a test for this but noticed that we can't write/pass JSX in `blog_test.ts` https://github.com/denoland/deno_blog/blob/345eedf5e0fd77f139cb4358e985234329bf1993/blog_test.ts#L13-L25