### PR TITLE
Feat/accept plaintext

### DIFF
--- a/blog.tsx
+++ b/blog.tsx
@@ -373,8 +373,10 @@ export async function handler(
   const post = POSTS.get(pathname);
   if (post) {
     // Check for an Accept: text/plain header
-    if (req.headers.has('Accept') && req.headers.get('Accept') === 'text/plain') {
-        return new Response(post.markdown);
+    if (
+      req.headers.has("Accept") && req.headers.get("Accept") === "text/plain"
+    ) {
+      return new Response(post.markdown);
     }
     return html({
       ...sharedHtmlOptions,

--- a/blog.tsx
+++ b/blog.tsx
@@ -372,6 +372,10 @@ export async function handler(
 
   const post = POSTS.get(pathname);
   if (post) {
+    // Check for an Accept: text/plain header
+    if (req.headers.has('Accept') && req.headers.get('Accept') === 'text/plain') {
+        return new Response(post.markdown);
+    }
     return html({
       ...sharedHtmlOptions,
       title: post.title,

--- a/blog_test.ts
+++ b/blog_test.ts
@@ -228,5 +228,5 @@ Deno.test("Plaintext response", async () => {
     "text/plain;charset=UTF-8",
   );
   const body = await resp.text();
-  assert(body.startsWith('It was popularised in the 1960s'));
+  assert(body.startsWith("It was popularised in the 1960s"));
 });

--- a/blog_test.ts
+++ b/blog_test.ts
@@ -211,3 +211,22 @@ Deno.test("RSS feed", async () => {
   assertStringIncludes(body, `Second post`);
   assertStringIncludes(body, `https://blog.deno.dev/second`);
 });
+
+Deno.test("Plaintext response", async () => {
+  const plaintext = new Headers({
+    "Accept": "text/plain",
+  });
+  const resp = await testHandler(
+    new Request("https://blog.deno.dev/first", {
+      headers: plaintext,
+    }),
+  );
+  assert(resp);
+  assertEquals(resp.status, 200);
+  assertEquals(
+    resp.headers.get("content-type"),
+    "text/plain;charset=UTF-8",
+  );
+  const body = await resp.text();
+  assert(body.startsWith('It was popularised in the 1960s'));
+});


### PR DESCRIPTION
Inspired by https://news.ycombinator.com/item?id=32248404

Small change that allows deno_blog to serve requests as plain text if that's what is specified in the `Accept` http header. 