### PR TITLE
Add render math functionality

### DIFF
--- a/blog.tsx
+++ b/blog.tsx
@@ -79,7 +79,7 @@ function hmrSocket(callback) {
 `;
 
 function errorHandler(err: unknown) {
-  return new Response(`Internal server error: ${(err as Error)?.message}`, {
+  return new Response(`Internal server error: ${ (err as Error)?.message }`, {
     status: 500,
   });
 }
@@ -200,7 +200,7 @@ async function loadContent(blogDirectory: string, isDev: boolean) {
   }
 
   if (isDev) {
-    watchForChanges(postsDirectory).catch(() => {});
+    watchForChanges(postsDirectory).catch(() => { });
   }
 }
 
@@ -217,7 +217,7 @@ async function watchForChanges(postsDirectory: string) {
               socket.send("refresh");
             });
           } catch (err) {
-            console.error(`loadPost ${path} error:`, err.message);
+            console.error(`loadPost ${ path } error:`, err.message);
           }
         }
       }
@@ -267,6 +267,7 @@ async function loadPost(postsDirectory: string, path: string) {
     tags: data.get("tags"),
     allowIframes: data.get("allow_iframes"),
     readTime: readingTime(content),
+    renderMath: data.get("render_math"),
   };
   POSTS.set(pathname, post);
 }
@@ -418,28 +419,28 @@ function serveRSS(
     ? new URL(state.canonicalUrl)
     : new URL(req.url);
   const origin = url.origin;
-  const copyright = `Copyright ${new Date().getFullYear()} ${origin}`;
+  const copyright = `Copyright ${ new Date().getFullYear() } ${ origin }`;
   const feed = new Feed({
     title: state.title ?? "Blog",
     description: state.description,
-    id: `${origin}/blog`,
-    link: `${origin}/blog`,
+    id: `${ origin }/blog`,
+    link: `${ origin }/blog`,
     language: state.lang ?? "en",
-    favicon: `${origin}/favicon.ico`,
+    favicon: `${ origin }/favicon.ico`,
     copyright: copyright,
     generator: "Feed (https://github.com/jpmonette/feed) for Deno",
     feedLinks: {
-      atom: `${origin}/feed`,
+      atom: `${ origin }/feed`,
     },
   });
 
   for (const [_key, post] of posts.entries()) {
     const item: FeedItem = {
-      id: `${origin}/${post.title}`,
+      id: `${ origin }/${ post.title }`,
       title: post.title,
       description: post.snippet,
       date: post.publishDate,
-      link: `${origin}${post.pathname}`,
+      link: `${ origin }${ post.pathname }`,
       author: post.author?.split(",").map((author: string) => ({
         name: author.trim(),
       })),
@@ -477,7 +478,7 @@ export function ga(gaKey: string): BlogMiddleware {
       res = await ctx.next() as Response;
     } catch (e) {
       err = e as Error;
-      res = new Response(`Internal server error: ${err.message}`, {
+      res = new Response(`Internal server error: ${ err.message }`, {
         status: 500,
       });
     } finally {
@@ -516,7 +517,7 @@ export function redirects(redirectMap: Record<string, string>): BlogMiddleware {
       return await ctx.next();
     } catch (e) {
       console.error(e);
-      return new Response(`Internal server error: ${e.message}`, {
+      return new Response(`Internal server error: ${ e.message }`, {
         status: 500,
       });
     }

--- a/blog.tsx
+++ b/blog.tsx
@@ -79,7 +79,7 @@ function hmrSocket(callback) {
 `;
 
 function errorHandler(err: unknown) {
-  return new Response(`Internal server error: ${ (err as Error)?.message }`, {
+  return new Response(`Internal server error: ${(err as Error)?.message}`, {
     status: 500,
   });
 }
@@ -200,7 +200,7 @@ async function loadContent(blogDirectory: string, isDev: boolean) {
   }
 
   if (isDev) {
-    watchForChanges(postsDirectory).catch(() => { });
+    watchForChanges(postsDirectory).catch(() => {});
   }
 }
 
@@ -217,7 +217,7 @@ async function watchForChanges(postsDirectory: string) {
               socket.send("refresh");
             });
           } catch (err) {
-            console.error(`loadPost ${ path } error:`, err.message);
+            console.error(`loadPost ${path} error:`, err.message);
           }
         }
       }
@@ -419,28 +419,28 @@ function serveRSS(
     ? new URL(state.canonicalUrl)
     : new URL(req.url);
   const origin = url.origin;
-  const copyright = `Copyright ${ new Date().getFullYear() } ${ origin }`;
+  const copyright = `Copyright ${new Date().getFullYear()} ${origin}`;
   const feed = new Feed({
     title: state.title ?? "Blog",
     description: state.description,
-    id: `${ origin }/blog`,
-    link: `${ origin }/blog`,
+    id: `${origin}/blog`,
+    link: `${origin}/blog`,
     language: state.lang ?? "en",
-    favicon: `${ origin }/favicon.ico`,
+    favicon: `${origin}/favicon.ico`,
     copyright: copyright,
     generator: "Feed (https://github.com/jpmonette/feed) for Deno",
     feedLinks: {
-      atom: `${ origin }/feed`,
+      atom: `${origin}/feed`,
     },
   });
 
   for (const [_key, post] of posts.entries()) {
     const item: FeedItem = {
-      id: `${ origin }/${ post.title }`,
+      id: `${origin}/${post.title}`,
       title: post.title,
       description: post.snippet,
       date: post.publishDate,
-      link: `${ origin }${ post.pathname }`,
+      link: `${origin}${post.pathname}`,
       author: post.author?.split(",").map((author: string) => ({
         name: author.trim(),
       })),
@@ -478,7 +478,7 @@ export function ga(gaKey: string): BlogMiddleware {
       res = await ctx.next() as Response;
     } catch (e) {
       err = e as Error;
-      res = new Response(`Internal server error: ${ err.message }`, {
+      res = new Response(`Internal server error: ${err.message}`, {
         status: 500,
       });
     } finally {
@@ -517,7 +517,7 @@ export function redirects(redirectMap: Record<string, string>): BlogMiddleware {
       return await ctx.next();
     } catch (e) {
       console.error(e);
-      return new Response(`Internal server error: ${ e.message }`, {
+      return new Response(`Internal server error: ${e.message}`, {
         status: 500,
       });
     }

--- a/blog_test.ts
+++ b/blog_test.ts
@@ -211,3 +211,12 @@ Deno.test("RSS feed", async () => {
   assertStringIncludes(body, `Second post`);
   assertStringIncludes(body, `https://blog.deno.dev/second`);
 });
+
+Deno.test("Math in posts", async () => {
+  const resp = await testHandler(new Request("https://blog.deno.dev/first"));
+  assert(resp);
+  assertEquals(resp.status, 200);
+  assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
+  const body = await resp.text();
+  assertStringIncludes(body, `<semantics><mrow><mi>f</mi><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><annotation encoding="application/x-tex">f(x)</annotation></semantics></math></span></span>`);
+});

--- a/blog_test.ts
+++ b/blog_test.ts
@@ -218,5 +218,8 @@ Deno.test("Math in posts", async () => {
   assertEquals(resp.status, 200);
   assertEquals(resp.headers.get("content-type"), "text/html; charset=utf-8");
   const body = await resp.text();
-  assertStringIncludes(body, `<semantics><mrow><mi>f</mi><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><annotation encoding="application/x-tex">f(x)</annotation></semantics></math></span></span>`);
+  assertStringIncludes(
+    body,
+    `<semantics><mrow><mi>f</mi><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><annotation encoding="application/x-tex">f(x)</annotation></semantics></math></span></span>`,
+  );
 });

--- a/components.tsx
+++ b/components.tsx
@@ -7,7 +7,7 @@
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-import { Fragment, gfm, h } from "./deps.ts";
+import { Fragment, gfm, h, katex } from "./deps.ts";
 import type { BlogState, DateFormat, Post } from "./types.d.ts";
 
 const socialAppIcons = new Map([
@@ -37,7 +37,7 @@ export function Index({ state, posts }: IndexProps) {
         <header
           class="w-full h-90 lt-sm:h-80 bg-cover bg-center bg-no-repeat"
           style={{
-            backgroundImage: state.cover ? `url(${state.cover})` : undefined,
+            backgroundImage: state.cover ? `url(${ state.cover })` : undefined,
           }}
         >
           <div class="max-w-screen-sm h-full px-6 mx-auto flex flex-col items-center justify-center">
@@ -50,7 +50,7 @@ export function Index({ state, posts }: IndexProps) {
                 ]
                   .filter(Boolean)
                   .join(" ")}
-                style={{ backgroundImage: `url(${state.avatar})` }}
+                style={{ backgroundImage: `url(${ state.avatar })` }}
               />
             )}
             <h1
@@ -148,7 +148,7 @@ function PostCard(
         <a
           class="leading-tight text-gray-900 dark:text-gray-100 inline-block border-b-1 border-gray-600 hover:text-gray-500 hover:border-gray-500 transition-colors"
           href={post.pathname}
-          title={`Read "${post.title}"`}
+          title={`Read "${ post.title }"`}
         >
           Read More
         </a>
@@ -162,12 +162,40 @@ interface PostPageProps {
   post: Post;
 }
 
+const inlineMathRegex = /\s\$([^\s$].+[^\s])\$/g;
+const blockMathRegex = /\$\$([^\$]+)\$\$/g;
+const katexOptions = {
+  throwOnError: false,
+  output: "mathml",
+};
+
 export function PostPage({ post, state }: PostPageProps) {
-  const html = gfm.render(post.markdown, {
+  let html = gfm.render(post.markdown, {
     allowIframes: post.allowIframes,
   });
+
+  if (post.renderMath) {
+    html = html.replace(inlineMathRegex, (_, math) => {
+      try {
+        return ` <span class="inline-math">${ katex.renderToString(math, katexOptions) }</span> `;
+      } catch (e) {
+        console.error(e);
+        return ` <span class="inline-math">${ math }</span> `;
+      }
+    });
+
+    html = html.replace(blockMathRegex, (_, math) => {
+      try {
+        return ` <div class="block-math">${ katex.renderToString(math, katexOptions) }</div> `;
+      } catch (e) {
+        console.error(e);
+        return ` <div class="block-math">${ math }</div> `;
+      }
+    });
+  }
+
   return (
-    <div className={`post ${post.pathname.substring(1)}`}>
+    <div className={`post ${ post.pathname.substring(1) }`}>
       {state.showHeaderOnPostPage && state.header}
       <div class="max-w-screen-sm px-6 pt-8 mx-auto">
         <div class="pb-16">
@@ -301,7 +329,7 @@ function Tags({ tags }: { tags?: string[] }) {
     ? (
       <section class="flex gap-x-2 flex-wrap">
         {tags?.map((tag) => (
-          <a class="text-bluegray-500 font-bold" href={`/?tag=${tag}`}>
+          <a class="text-bluegray-500 font-bold" href={`/?tag=${ tag }`}>
             #{tag}
           </a>
         ))}

--- a/components.tsx
+++ b/components.tsx
@@ -37,7 +37,7 @@ export function Index({ state, posts }: IndexProps) {
         <header
           class="w-full h-90 lt-sm:h-80 bg-cover bg-center bg-no-repeat"
           style={{
-            backgroundImage: state.cover ? `url(${ state.cover })` : undefined,
+            backgroundImage: state.cover ? `url(${state.cover})` : undefined,
           }}
         >
           <div class="max-w-screen-sm h-full px-6 mx-auto flex flex-col items-center justify-center">
@@ -50,7 +50,7 @@ export function Index({ state, posts }: IndexProps) {
                 ]
                   .filter(Boolean)
                   .join(" ")}
-                style={{ backgroundImage: `url(${ state.avatar })` }}
+                style={{ backgroundImage: `url(${state.avatar})` }}
               />
             )}
             <h1
@@ -148,7 +148,7 @@ function PostCard(
         <a
           class="leading-tight text-gray-900 dark:text-gray-100 inline-block border-b-1 border-gray-600 hover:text-gray-500 hover:border-gray-500 transition-colors"
           href={post.pathname}
-          title={`Read "${ post.title }"`}
+          title={`Read "${post.title}"`}
         >
           Read More
         </a>
@@ -177,25 +177,29 @@ export function PostPage({ post, state }: PostPageProps) {
   if (post.renderMath) {
     html = html.replace(inlineMathRegex, (_, math) => {
       try {
-        return ` <span class="inline-math">${ katex.renderToString(math, katexOptions) }</span> `;
+        return ` <span class="inline-math">${
+          katex.renderToString(math, katexOptions)
+        }</span> `;
       } catch (e) {
         console.error(e);
-        return ` <span class="inline-math">${ math }</span> `;
+        return ` <span class="inline-math">${math}</span> `;
       }
     });
 
     html = html.replace(blockMathRegex, (_, math) => {
       try {
-        return ` <div class="block-math">${ katex.renderToString(math, katexOptions) }</div> `;
+        return ` <div class="block-math">${
+          katex.renderToString(math, katexOptions)
+        }</div> `;
       } catch (e) {
         console.error(e);
-        return ` <div class="block-math">${ math }</div> `;
+        return ` <div class="block-math">${math}</div> `;
       }
     });
   }
 
   return (
-    <div className={`post ${ post.pathname.substring(1) }`}>
+    <div className={`post ${post.pathname.substring(1)}`}>
       {state.showHeaderOnPostPage && state.header}
       <div class="max-w-screen-sm px-6 pt-8 mx-auto">
         <div class="pb-16">
@@ -329,7 +333,7 @@ function Tags({ tags }: { tags?: string[] }) {
     ? (
       <section class="flex gap-x-2 flex-wrap">
         {tags?.map((tag) => (
-          <a class="text-bluegray-500 font-bold" href={`/?tag=${ tag }`}>
+          <a class="text-bluegray-500 font-bold" href={`/?tag=${tag}`}>
             #{tag}
           </a>
         ))}

--- a/deps.ts
+++ b/deps.ts
@@ -39,3 +39,5 @@ export type UnoConfig = typeof UnoCSS extends (
   arg: infer P | undefined,
 ) => unknown ? P
   : never;
+
+export { default as katex } from "https://cdn.jsdelivr.net/npm/katex@0.16.3/dist/katex.mjs";

--- a/testdata/posts/first.md
+++ b/testdata/posts/first.md
@@ -3,6 +3,7 @@ title: First post
 publish_date: 2022-03-20
 abstract: This is the first post.
 cover_html: <svg class="w-full" height="350" width="100%" background="black"><circle cx="50%" cy="170" r="150" stroke="white" stroke-width="10" fill="black" alpha="50%"/></svg>
+render_math: true
 ---
 
 It was popularised in the 1960s with the release of Letraset sheets containing
@@ -39,4 +40,24 @@ blog({
 });
 ```
 
-$100, $200, $300, $400, $500
+## Escape `\$` to avoid math conflicts
+
+$100, \$200, $300, $400, $500
+
+This is a test for rendering math.
+
+Inline math: $\varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887…$
+
+Test $f(x)$
+
+Block math:
+
+$$
+ \varphi = 1+\frac{1} {1+\frac{1} {1+\frac{1} {1+\cdots} } }
+$$
+
+$$
+\begin{aligned}
+  \frac{d}{dx} \int_a^x f(t) \,dt = f(x) + C \\
+\end{aligned}
+$$

--- a/types.d.ts
+++ b/types.d.ts
@@ -98,4 +98,5 @@ export interface Post {
   tags?: string[];
   allowIframes?: boolean;
   readTime: number;
+  renderMath?: boolean;
 }


### PR DESCRIPTION
I've always had to create pre-rendered svgs to show math on my blogs, so I thought about adding the math rendering directly from the server.

This pull request uses [katex](https://katex.org/) to render inline as well as block math directly on the server-side by setting `render_math` boolean in the post frontmatter.