### PR TITLE
Change github action to run when push or pull_request on any branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: ci
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push, pull_request]
 
 jobs:
   check:


### PR DESCRIPTION
As mentioned in this pr https://github.com/denoland/deno_blog/pull/109.

It can't run github action on my fork repo's other branches. I think it should be like this:

```yml
on: [push, pull_request]
```