### PR TITLE
fix: routing with custom pathname

### DIFF
--- a/blog.tsx
+++ b/blog.tsx
@@ -252,12 +252,14 @@ async function loadPost(postsDirectory: string, path: string) {
     }
   }
 
+  // Note: users can override path of a blog post using
+    // pathname in front matter.
+  pathname = data.get("pathname") ?? pathname
+
   const post: Post = {
     title: data.get("title") ?? "Untitled",
     author: data.get("author"),
-    // Note: users can override path of a blog post using
-    // pathname in front matter.
-    pathname: data.get("pathname") ?? pathname,
+    pathname,
     // Note: no error when publish_date is wrong or missed
     publishDate: data.get("publish_date") instanceof Date
       ? data.get("publish_date")!


### PR DESCRIPTION
Currently when you try to load a route that has a custom pathname set it will 404, because it still expects the request url to match the filepath. Using the pathname defined in front matter for the `POSTS` key fixes this.