### PR TITLE
Update dependency (deno.land/std)

### DIFF
--- a/blog.tsx
+++ b/blog.tsx
@@ -22,14 +22,13 @@ import {
   join,
   relative,
   removeMarkdown,
-  serve,
   serveDir,
   UnoCSS,
   walk,
 } from "./deps.ts";
 import { pooledMap } from "https://deno.land/std@0.214.0/async/pool.ts";
 import { Index, PostPage } from "./components.tsx";
-import type { ConnInfo, FeedItem } from "./deps.ts";
+import type { FeedItem } from "./deps.ts";
 import type {
   BlogContext,
   BlogMiddleware,
@@ -110,17 +109,17 @@ export default async function blog(settings?: BlogSettings) {
   const blogState = await configureBlog(url, IS_DEV, settings);
 
   const blogHandler = createBlogHandler(blogState);
-  serve(blogHandler, {
+  Deno.serve({
     port: blogState.port,
     hostname: blogState.hostname,
     onError: errorHandler,
-  });
+  }, blogHandler);
 }
 
 export function createBlogHandler(state: BlogState) {
   const inner = handler;
   const withMiddlewares = composeMiddlewares(state);
-  return function handler(req: Request, connInfo: ConnInfo) {
+  return function handler(req: Request, connInfo: Deno.ServeHandlerInfo) {
     // Redirect requests that end with a trailing slash
     // to their non-trailing slash counterpart.
     // Ex: /about/ -> /about
@@ -136,7 +135,7 @@ export function createBlogHandler(state: BlogState) {
 function composeMiddlewares(state: BlogState) {
   return (
     req: Request,
-    connInfo: ConnInfo,
+    connInfo: Deno.ServeHandlerInfo,
     inner: (req: Request, ctx: BlogContext) => Promise<Response>,
   ) => {
     const mws = state.middlewares?.slice().reverse();

--- a/blog.tsx
+++ b/blog.tsx
@@ -27,7 +27,7 @@ import {
   UnoCSS,
   walk,
 } from "./deps.ts";
-import { pooledMap } from "https://deno.land/std@0.187.0/async/pool.ts";
+import { pooledMap } from "https://deno.land/std@0.214.0/async/pool.ts";
 import { Index, PostPage } from "./components.tsx";
 import type { ConnInfo, FeedItem } from "./deps.ts";
 import type {
@@ -37,7 +37,7 @@ import type {
   BlogState,
   Post,
 } from "./types.d.ts";
-import { WalkEntry } from "https://deno.land/std@0.176.0/fs/walk.ts";
+import { WalkEntry } from "https://deno.land/std@0.214.0/fs/walk.ts";
 
 export { Fragment, h };
 

--- a/blog_test.ts
+++ b/blog_test.ts
@@ -5,7 +5,7 @@ import {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "https://deno.land/std@0.214.0/testing/asserts.ts";
+} from "https://deno.land/std@0.214.0/assert/mod.ts";
 import { fromFileUrl, join } from "https://deno.land/std@0.214.0/path/mod.ts";
 
 const BLOG_URL = new URL("./testdata/main.js", import.meta.url).href;

--- a/blog_test.ts
+++ b/blog_test.ts
@@ -5,8 +5,8 @@ import {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "https://deno.land/std@0.193.0/testing/asserts.ts";
-import { fromFileUrl, join } from "https://deno.land/std@0.193.0/path/mod.ts";
+} from "https://deno.land/std@0.214.0/testing/asserts.ts";
+import { fromFileUrl, join } from "https://deno.land/std@0.214.0/path/mod.ts";
 
 const BLOG_URL = new URL("./testdata/main.js", import.meta.url).href;
 const TESTDATA_PATH = fromFileUrl(new URL("./testdata/", import.meta.url));

--- a/deps.ts
+++ b/deps.ts
@@ -8,10 +8,6 @@ export {
   join,
   relative,
 } from "https://deno.land/std@0.214.0/path/mod.ts";
-export {
-  type ConnInfo,
-  serve,
-} from "https://deno.land/std@0.214.0/http/mod.ts";
 export { extract as frontMatter } from "https://deno.land/std@0.214.0/front_matter/any.ts";
 
 export * as gfm from "https://deno.land/x/gfm@0.2.5/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,18 +1,18 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-export { serveDir } from "https://deno.land/std@0.193.0/http/file_server.ts";
-export { walk } from "https://deno.land/std@0.193.0/fs/walk.ts";
+export { serveDir } from "https://deno.land/std@0.214.0/http/file_server.ts";
+export { walk } from "https://deno.land/std@0.214.0/fs/walk.ts";
 export {
   dirname,
   fromFileUrl,
   join,
   relative,
-} from "https://deno.land/std@0.193.0/path/mod.ts";
+} from "https://deno.land/std@0.214.0/path/mod.ts";
 export {
   type ConnInfo,
   serve,
-} from "https://deno.land/std@0.193.0/http/mod.ts";
-export { extract as frontMatter } from "https://deno.land/std@0.193.0/front_matter/any.ts";
+} from "https://deno.land/std@0.214.0/http/mod.ts";
+export { extract as frontMatter } from "https://deno.land/std@0.214.0/front_matter/any.ts";
 
 export * as gfm from "https://deno.land/x/gfm@0.2.5/mod.ts";
 export { Fragment, h } from "https://deno.land/x/htm@0.1.3/mod.ts";

--- a/init.ts
+++ b/init.ts
@@ -1,6 +1,6 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-import { join, resolve } from "https://deno.land/std@0.193.0/path/mod.ts";
+import { join, resolve } from "https://deno.land/std@0.214.0/path/mod.ts";
 
 const HELP = `deno_blog
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,10 +1,10 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-import type { ConnInfo, UnoConfig, VNode } from "./deps.ts";
+import type { UnoConfig, VNode } from "./deps.ts";
 
 export interface BlogContext {
   state: BlogState;
-  connInfo: ConnInfo;
+  connInfo: Deno.ServeHandlerInfo;
   next: () => Promise<Response>;
 }
 


### PR DESCRIPTION
The std library is updated (from 0.187.0 to 0.214.0)

I also stopped using deprecated functions.
1. Move to Deno.serve from std/http/serve.
2. Move std/testing/asserts to std/assert.