### PR TITLE
Theme fix

### DIFF
--- a/blog.tsx
+++ b/blog.tsx
@@ -104,7 +104,7 @@ function errorHandler(err: unknown) {
  */
 export default async function blog(settings?: BlogSettings) {
   html.use(UnoCSS(settings?.unocss)); // Load custom unocss module if provided
-  html.use(ColorScheme("auto"));
+  html.use(ColorScheme(settings?.theme == "dark" ? "dark" : "auto"));
 
   const url = callsites()[1].getFileName()!;
   const blogState = await configureBlog(url, IS_DEV, settings);

--- a/components.tsx
+++ b/components.tsx
@@ -217,8 +217,8 @@ export function PostPage({ post, state }: PostPageProps) {
           <div
             class="mt-8 markdown-body"
             data-color-mode={state.theme ?? "auto"}
-            data-light-theme="light"
-            data-dark-theme="dark"
+            data-light-theme={state.theme ?? "light"}
+            data-dark-theme={state.theme ?? "dark"}
             dangerouslySetInnerHTML={{ __html: html }}
           />
         </article>

--- a/deps.ts
+++ b/deps.ts
@@ -14,7 +14,7 @@ export {
 } from "https://deno.land/std@0.193.0/http/mod.ts";
 export { extract as frontMatter } from "https://deno.land/std@0.193.0/front_matter/any.ts";
 
-export * as gfm from "https://deno.land/x/gfm@0.2.5/mod.ts";
+export * as gfm from 'https://deno.land/x/gfm@0.6.0/mod.ts'
 export { Fragment, h } from "https://deno.land/x/htm@0.1.3/mod.ts";
 export {
   default as html,

--- a/deps.ts
+++ b/deps.ts
@@ -14,7 +14,7 @@ export {
 } from "https://deno.land/std@0.193.0/http/mod.ts";
 export { extract as frontMatter } from "https://deno.land/std@0.193.0/front_matter/any.ts";
 
-export * as gfm from 'https://deno.land/x/gfm@0.6.0/mod.ts'
+export * as gfm from "https://deno.land/x/gfm@0.6.0/mod.ts";
 export { Fragment, h } from "https://deno.land/x/htm@0.1.3/mod.ts";
 export {
   default as html,


### PR DESCRIPTION
Fixes #140 

Use the theme state in `ColorScheme` and `Component` to correctly handle browser settings. See #140 for an example

this did not work for Firefox + Night Mode, but appears to work everywhere else.